### PR TITLE
Fix race condition when SYN is successfully sent

### DIFF
--- a/session.go
+++ b/session.go
@@ -175,11 +175,7 @@ GET_ID:
 
 	// Send the window update to create
 	if err := stream.sendWindowUpdate(); err != nil {
-		select {
-		case <-s.synCh:
-		default:
-			s.logger.Printf("[ERR] yamux: aborted stream open without inflight syn semaphore")
-		}
+		s.closeStream(id)
 		return nil, err
 	}
 	return stream, nil
@@ -468,7 +464,7 @@ func (s *Session) handleStreamMessage(hdr header) error {
 	stream := s.streams[id]
 	s.streamLock.Unlock()
 
-	// If we do not have a stream, likely we sent a RST
+	// If we do not have a stream, likely we sent a RST or an error occurred sending a SYN
 	if stream == nil {
 		// Drain any data on the wire
 		if hdr.MsgType() == typeData && hdr.Length() > 0 {
@@ -598,6 +594,7 @@ func (s *Session) incomingStream(id uint32) error {
 func (s *Session) closeStream(id uint32) {
 	s.streamLock.Lock()
 	if _, ok := s.inflight[id]; ok {
+		delete(s.inflight, id)
 		select {
 		case <-s.synCh:
 		default:


### PR DESCRIPTION
OpenStream did not properly cleanup if the `sendWindowUpdate` call failed. Calling `closeStream` correctly drains the inflight SYN semaphore and removes the stream from the `streams` map.